### PR TITLE
chore(dev): remove json object returns in loader function

### DIFF
--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import { json, type MetaFunction } from '@remix-run/node';
+import { type MetaFunction } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 
 export const meta: MetaFunction = () => {
@@ -9,7 +9,7 @@ export const loader = async () => {
   // fetch data from remote
   const name = 'John';
   const test = process.env.TEST;
-  return json({ name, test });
+  return { name, test };
 };
 
 export default function Index() {


### PR DESCRIPTION
remix@latestではloaderの返り値をjson()で返さなくてもよくなっていたので対応。
ドキュメントには反映されていないがリリースノートに書かれていた。

see:
https://github.com/remix-run/remix/blob/main/CHANGELOG.md#updated-type-safety-for-single-fetch